### PR TITLE
Revert "Bump OpenTelemetry.Instrumentation.AspNetCore from 1.0.0-rc9.14 to 1.8.1 in /chapter3/dapr/storage"

### DIFF
--- a/chapter3/dapr/storage/storage.csproj
+++ b/chapter3/dapr/storage/storage.csproj
@@ -14,7 +14,7 @@
     <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.4.0" />
     <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol.Logs" Version="1.4.0-rc.4" />
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.4.0" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.8.1" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.0.0-rc9.14" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.0.0-rc9.14" />
   </ItemGroup>
 


### PR DESCRIPTION
Reverts PacktPublishing/Modern-Distributed-Tracing-in-.NET#48